### PR TITLE
Various CSS fixes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,24 +11,25 @@ html{
 
 body{
     background: #333;
+    padding-left: 15px; /* compensate sidebar width */
 }
 
 .asideInfos{
-  position: absolute;
+  position: fixed;
   z-index: 9;
   left:-145px;
   top:0;
   height: 100%;
   width: 160px;
-  max-height: 100%; 
-  overflow: hidden; 
+  max-height: 100%;
+  overflow: hidden;
   background:#555555;
   transition: all 650ms;
 }
 
 .asideInfos:hover{
   left: 0px !important;
-  overflow-y: auto !important; 
+  overflow-y: auto !important;
   box-shadow: 4px 0px 9px #808080;
 }
 
@@ -164,7 +165,7 @@ h2{
 }
 
 label{
-    width: 89%;
+    width: 100%;
     text-align: center;
     font-size: 15px;
     color: #fff;
@@ -180,11 +181,9 @@ textarea{
     color: #ddd;
 }
 
-.textareaSection{
-    display: flex;
-    justify-content: center;
+#inputurl {
+  width: 100%;
 }
-
 
 .tryButton{
     height: 70px;
@@ -228,6 +227,11 @@ textarea{
 *
 */
 
+#stylesheet .jsoneditor,
+#input .jsoneditor,
+#output .jsoneditor {
+  width: 100%;
+}
 .jsoneditor .menu{
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -20,31 +20,31 @@
 <body>
     <a href="https://github.com/castorjs/node-jbj"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 
-    <h1 class="row">JBJ - Playground</h1>
-    <h2 class="row">Json By Json - A new way to transform JSON object with a JSON stylesheet. It's like XSL/XML but only with JSON. </h2>
+    <section class="container-fluid">
+      <h1 class="row">JBJ - Playground</h1>
+      <h2 class="row">Json By Json - A new way to transform JSON object with a JSON stylesheet. It's like XSL/XML but only with JSON. </h2>
 
-    <section class="container">
-      <div class="textareaSection">
-          <div class="col-lg-4">
+      <div class="row">
+          <div class="col-sm-12 col-md-4">
             <label for="input">INPUT :</label>
             <div id="input"></div>
             <label for="inputurl">URL:</label>
-            <input id="inputurl" type="url" style="width:90%">
+            <input id="inputurl" type="url">
           </div>
-          <div class="col-lg-4">
+          <div class="col-sm-12 col-md-4">
             <label for="stylesheet">STYLESHEET :</label>
             <div id="stylesheet"></div>
           </div>
-          <div class="col-lg-4">
+          <div class="col-sm-12 col-md-4">
             <label for="output">RESULT :</label>
             <div id="output"></div>
           </div>
       </div>
-      <div class="row" style="text-align: center; margin: 50px; ">
+      <div class="text-center row" style="margin: 50px; ">
           <button class="tryButton">TRY IT!</button>
       </div>
     </section>
-    <aside style="" class="asideInfos">
+    <aside class="asideInfos">
       <div id="enterAside" class="glyphicon glyphicon-chevron-right"></div>
       <div id="quitAside" class="glyphicon glyphicon-chevron-left" style="display: none"></div>
       <section id="examplesSection" style="display: none;">

--- a/index.html
+++ b/index.html
@@ -25,17 +25,17 @@
       <h2 class="row">Json By Json - A new way to transform JSON object with a JSON stylesheet. It's like XSL/XML but only with JSON. </h2>
 
       <div class="row">
-          <div class="col-sm-12 col-md-4">
+          <div class="col-xs-12 col-sm-4">
             <label for="input">INPUT :</label>
             <div id="input"></div>
             <label for="inputurl">URL:</label>
             <input id="inputurl" type="url">
           </div>
-          <div class="col-sm-12 col-md-4">
+          <div class="col-xs-12 col-sm-4">
             <label for="stylesheet">STYLESHEET :</label>
             <div id="stylesheet"></div>
           </div>
-          <div class="col-sm-12 col-md-4">
+          <div class="col-xs-12 col-sm-4">
             <label for="output">RESULT :</label>
             <div id="output"></div>
           </div>


### PR DESCRIPTION
Changes :
- The container is now full width and the columns **stack** for small screens,
- JSON editors are forced to **100% width** to fix the columns right padding,
- Aside menu is now **fixed** (fix its height in some cases)
- Add a padding to **body** to compensate the width of the menu,
- Put title/subtitles rows in the grid to avoid text overflow.
