### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "each-async": "^1.1.1",
     "extend": "^3.0.0",
     "filtrex": "^0.5.4",
-    "json-mask": "^0.3.2",
+    "json-mask": "^0.3.5",
     "mustache": "^2.2.1",
     "object-path": "^0.9.2",
     "transtype": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "JSONSelect": "https://github.com/touv/JSONSelect/archive/master.tar.gz",
     "async": "^1.5.2",
-    "csv-string": "^2.2.5",
+    "csv-string": "^2.3.0",
     "each-async": "^1.1.1",
     "extend": "^3.0.0",
     "filtrex": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "extend": "^2.0.0",
     "filtrex": "^0.5.4",
     "json-mask": "^0.3.2",
-    "mustache": "^1.0.0",
+    "mustache": "^2.2.1",
     "object-path": "^0.8.1",
     "transtype": "^1.0.0",
     "xml-mapping": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/istanbul test ./node_modules/.bin/_mocha -- -R spec"
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "JSONSelect": "https://github.com/touv/JSONSelect/archive/master.tar.gz",
-    "async": "^0.9.0",
+    "async": "^1.5.2",
     "csv-string": "^2.2.5",
     "each-async": "^1.1.1",
     "extend": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "filtrex": "^0.5.4",
     "json-mask": "^0.3.2",
     "mustache": "^2.2.1",
-    "object-path": "^0.8.1",
+    "object-path": "^0.9.2",
     "transtype": "^1.0.0",
     "xml-mapping": "^1.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async": "^1.5.2",
     "csv-string": "^2.2.5",
     "each-async": "^1.1.1",
-    "extend": "^2.0.0",
+    "extend": "^3.0.0",
     "filtrex": "^0.5.4",
     "json-mask": "^0.3.2",
     "mustache": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": ">=1.8.1",
-    "istanbul": "^0.2.14"
+    "istanbul": "^0.4.2"
   },
   "dependencies": {
     "JSONSelect": "https://github.com/touv/JSONSelect/archive/master.tar.gz",


### PR DESCRIPTION
Thanks to [David-DM](https://david-dm.org/Inist-CNRS/node-jbj), we found one insecure dependency (mustache), and 3 outdated dependencies (async, extend, object-path).

Also, the `test` command of `istanbul` depends on an `npm` variable which won't be set in last versions of `npm`. So I replaced it with `cover` which implies a systematic coverage...
